### PR TITLE
Add support for Docker Compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM maven:3-jdk-8
+
+EXPOSE 8080
+
+ADD . /usr/src/app
+WORKDIR /usr/src/app
+RUN mvn clean install -e
+
+WORKDIR /usr/src/app/webapp
+CMD mvn jetty:run
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+graphite:
+  image: hopsoft/graphite-statsd
+  ports:
+    - "80:80"
+    - "2003:2003"
+    - "8125:8125/udp"
+
+maven:
+  #image: maven:3-jdk-8
+  build: .
+  ports:
+    - "8080:8080"
+  volumes:
+    - .:/usr/src/app
+


### PR DESCRIPTION
This PR add a working Docker Compose setup with two containers; `maven` and `graphite`. Everything is set up via Docker compose and source code is mapped as a volume to the `maven` container such that no restart is required. 

**Requirements:**
- [Docker](https://github.com/docker/docker) v1.5.0
- [Docker Compose](https://github.com/docker/compose) v1.1.0

**Usage:**

```
docker-compose pull
docker-compose build
docker-compose up
```
